### PR TITLE
Correct phpunit example in README:

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $this->tearDownHttpMock();
     }
 
-    public function testSimpleRequest($path)
+    public function testSimpleRequest()
     {
         $this->http->mock
             ->when()


### PR DESCRIPTION
- Correct expectation of HTTP method
- Correct assertion of body content to compare two strings (with latest version of guzzle 4.1.6)
