### PR TITLE
Add PHP 5.4.0 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
      "require": {
+        "php": ">=5.4.0",
         "silex/silex": "~1",
         "guzzle/guzzle": "*",
         "symfony/process": "*",


### PR DESCRIPTION
PHP prior to 5.4 does not have a built-in webserver.