### PR TITLE
Fixing PHP Warning for type declaration in Server start function

### DIFF
--- a/src/InterNations/Component/HttpMock/Server.php
+++ b/src/InterNations/Component/HttpMock/Server.php
@@ -30,7 +30,7 @@ class Server extends Process
         $this->setTimeout(null);
     }
 
-    public function start($callback = null)
+    public function start(callable $callback = null)
     {
         parent::start($callback);
         $this->pollWait();


### PR DESCRIPTION
Without this you get the following non-fatal warning:

PHP Warning:  Declaration of InterNations\Component\HttpMock\Server::start($callback = NULL) should be compatible with Symfony\Component\Process\Process::start(callable $callback = NULL) in /home/david/PhpstormProjects/darktec/Http/vendor/internations/http-mock/src/InterNations/Component/HttpMock/Server.php on line 11