### PR TITLE
Change required symfony/process version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.4.0",
         "silex/silex": "~1",
         "guzzle/guzzle": "*",
-        "symfony/process": "*",
+        "symfony/process": "~3",
         "jeremeamia/superclosure": "~2",
         "lstrojny/hmmmath": ">=0.5.0"
     },


### PR DESCRIPTION
Fix error on symfony 2.7: "PHP Strict standards:  Declaration of InterNations\Component\HttpMock\Server::start() should be compatible with Symfony\Component\Process\Process::start($callback = NULL) in vendor/internations/http-mock/src/InterNations/Component/HttpMock/Server.php on line 12".

Package versions:
http-mock: 0.7.2
symfony/process: 2.7.9

With http-mock v0.7.0 works fine.

After [this commit] (https://github.com/InterNations/http-mock/commit/db6fc3c6be8a5e0c6b6ed1e1c51c7b13ce2cf2bc) http-mock can works only with [symfony/process > 3.0](https://github.com/symfony/process/commit/606e8f7efe670baa0de63450fd8d86c5398636af)