### PR TITLE
Provide an absolute path to the router for the PHP CLI server to fix "No such file or directory" error

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -20,12 +20,14 @@ class Server extends Process
     {
         $this->port = $port;
         $this->host = $host;
+        $package_root = __DIR__ . '/../';
         parent::__construct(
             sprintf(
-                'exec php -dalways_populate_raw_post_data=-1 -derror_log= -S %s -t public/ public/index.php',
-                $this->getConnectionString()
+                'exec php -dalways_populate_raw_post_data=-1 -derror_log= -S %s -t public/ %spublic/index.php',
+                $this->getConnectionString(),
+                $package_root
             ),
-            __DIR__ . '/../'
+            $package_root
         );
         $this->setTimeout(null);
     }


### PR DESCRIPTION
In PHP source commit: https://github.com/php/php-src/commit/816758eda2bcdd69ba505fb6bbb79124a7bf2254 made to fix [#75287](https://bugs.php.net/bug.php?id=75287), there is a change to how the router argument is passed in. Previously, the CLI accepted relative paths (to the current working directory) for the router argument. After this change, it either uses an absolute path, or concatenates the server docroot and the router if an absolute path is not provided. This causes the error seen in #39.

While normally this would be fixed by just changing the router argument to `index.php`, it breaks compatibility with PHP version 7.1.11 and below as those versions expect an absolute path. Thus, this fix involves getting the absolute path to the router file and passing that in instead.

I have tested this on both 7.1.11 and 7.1.12 and it works.