### PR TITLE
Follow up of: Provide an absolute path to the router for the PHP CLI server to fix "No such file or directory" error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
   - nightly
   - hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         "lstrojny/hmmmath": ">=0.5.0"
     },
     "require-dev": {
-        "internations/kodierungsregelwerksammlung": "dev-master",
-        "internations/testing-component": "dev-master",
-        "phpunit/phpunit": ">=6"
+        "internations/kodierungsregelwerksammlung": "0.24.1",
+        "internations/testing-component": "1.0.1",
+        "phpunit/phpunit": "6.0"
     },
     "autoload": {
         "psr-4": {"InterNations\\Component\\HttpMock\\": "src/"}

--- a/src/Server.php
+++ b/src/Server.php
@@ -20,12 +20,14 @@ class Server extends Process
     {
         $this->port = $port;
         $this->host = $host;
+        $package_root = __DIR__ . '/../';
         parent::__construct(
             sprintf(
-                'exec php -dalways_populate_raw_post_data=-1 -derror_log= -S %s -t public/ public/index.php',
-                $this->getConnectionString()
+                'exec php -dalways_populate_raw_post_data=-1 -derror_log= -S %s -t public/ %spublic/index.php',
+                $this->getConnectionString(),
+                $package_root
             ),
-            __DIR__ . '/../'
+            $package_root
         );
         $this->setTimeout(null);
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -20,14 +20,14 @@ class Server extends Process
     {
         $this->port = $port;
         $this->host = $host;
-        $package_root = __DIR__ . '/../';
+        $packageRoot = __DIR__ . '/../';
         parent::__construct(
             sprintf(
                 'exec php -dalways_populate_raw_post_data=-1 -derror_log= -S %s -t public/ %spublic/index.php',
                 $this->getConnectionString(),
-                $package_root
+                $packageRoot
             ),
-            $package_root
+            $packageRoot
         );
         $this->setTimeout(null);
     }


### PR DESCRIPTION
This PR is a follow up of #39 and it has been created because Travis is currently setup to just run on PRs, while if it would run on each push, we would not need this second PR.

