### PR TITLE
Fix error when absolute path contains spaces

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -21,11 +21,12 @@ class Server extends Process
         $this->port = $port;
         $this->host = $host;
         $packageRoot = __DIR__ . '/../';
+        $packagePath = escapeshellarg($packageRoot . 'public/index.php');
         parent::__construct(
             sprintf(
-                'exec php -dalways_populate_raw_post_data=-1 -derror_log= -S %s -t public/ %spublic/index.php',
+                'exec php -dalways_populate_raw_post_data=-1 -derror_log= -S %s -t public/ %s',
                 $this->getConnectionString(),
-                $packageRoot
+                $packagePath
             ),
             $packageRoot
         );


### PR DESCRIPTION
Hi,

Pull request is to fix an error that occurs when the absolute path has spaces in it.

To reproduce rename the project directory from `http-mock` to `http mock` and then run PHPUnit tests