### PR TITLE
Implement and test header matchers

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -103,6 +103,20 @@ class Expectation
         return $this;
     }
 
+    public function headerIs($name, $value)
+    {
+        $this->appendMatcher($value, $this->extractorFactory->createHeaderExtractor($name));
+
+        return $this;
+    }
+
+    public function headerExists($name)
+    {
+        $this->appendMatcher(true, $this->extractorFactory->createHeaderExistsExtractor($name));
+
+        return $this;
+    }
+
     public function callback(Closure $callback)
     {
         $this->appendMatcher($this->matcherFactory->closure($callback));

--- a/src/Matcher/ExtractorFactory.php
+++ b/src/Matcher/ExtractorFactory.php
@@ -41,4 +41,18 @@ class ExtractorFactory
             return $request->query->has($param);
         };
     }
+
+    public function createHeaderExtractor($header)
+    {
+        return static function (Request $request) use ($header) {
+            return $request->headers->get($header);
+        };
+    }
+
+    public function createHeaderExistsExtractor($header)
+    {
+        return static function (Request $request) use ($header) {
+            return $request->headers->has($header);
+        };
+    }
 }

--- a/tests/Matcher/ExtractorFactoryTest.php
+++ b/tests/Matcher/ExtractorFactoryTest.php
@@ -80,4 +80,72 @@ class ExtractorFactoryTest extends AbstractTestCase
         $extractor = $extractorFactory->createPathExtractor();
         $this->assertSame('', $extractor($this->request));
     }
+
+    public function testGetHeaderWithExistingHeader()
+    {
+        $request = new Request(
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['HTTP_CONTENT_TYPE' => 'application/json']
+        );
+
+        $extractorFactory = new ExtractorFactory('/foo');
+
+        $extractor = $extractorFactory->createHeaderExtractor('content-type');
+        $this->assertSame('application/json', $extractor($request));
+    }
+
+    public function testGetHeaderWithNonExistingHeader()
+    {
+        $request = new Request(
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['HTTP_X_FOO' => 'bar']
+        );
+
+        $extractorFactory = new ExtractorFactory('/foo');
+
+        $extractor = $extractorFactory->createHeaderExtractor('content-type');
+        $this->assertSame(null, $extractor($request));
+    }
+
+    public function testHeaderExistsWithExistingHeader()
+    {
+        $request = new Request(
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['HTTP_CONTENT_TYPE' => 'application/json']
+        );
+
+        $extractorFactory = new ExtractorFactory('/foo');
+
+        $extractor = $extractorFactory->createHeaderExistsExtractor('content-type');
+        $this->assertTrue($extractor($request));
+    }
+
+    public function testHeaderExistsWithNonExistingHeader()
+    {
+        $request = new Request(
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['HTTP_X_FOO' => 'bar']
+        );
+
+        $extractorFactory = new ExtractorFactory('/foo');
+
+        $extractor = $extractorFactory->createHeaderExistsExtractor('content-type');
+        $this->assertFalse($extractor($request));
+    }
 }


### PR DESCRIPTION
This implements two new matchers:

* `->headerIs($name, $value)`
* `->headerExists($name)`

This could replace the unfinished PR #27.

Open question:
* **How should headers with multiple values be handled?** The previous PR implemented `headerIs` in such a way that it checked all headers matching the given header name. This one currently only checks the first (which should be fine for close to all use-cases). Do you want to support headers with multiple values? If so, as part of the `headerIs()` function or a separate one?
* **Are the current tests okay?** In the other PR, you mentioned integration tests, but here they (currently, depending on the previous point) are not necessary, because there were already unit tests for the `ExtractorFactory` class. If you want them, where should I place these test cases?
