### PR TITLE
Fixes #53 Do not interpret log output as errors

### DIFF
--- a/src/PHPUnit/HttpMockTrait.php
+++ b/src/PHPUnit/HttpMockTrait.php
@@ -69,7 +69,7 @@ trait HttpMockTrait
             function (HttpMockFacade $facade) {
                 $this->assertSame(
                     '',
-                    (string) $facade->server->getIncrementalErrorOutput(),
+                    (string) $facade->getErrorOutput(),
                     'HTTP mock server standard error output should be empty'
                 );
             }

--- a/tests/AppIntegrationTest.php
+++ b/tests/AppIntegrationTest.php
@@ -1,16 +1,16 @@
 <?php
 namespace InterNations\Component\HttpMock\Tests;
 
-use InterNations\Component\HttpMock\Server;
-use InterNations\Component\Testing\AbstractTestCase;
 use Guzzle\Http\Client;
+use Guzzle\Http\Message\EntityEnclosingRequest;
 use Guzzle\Http\Message\RequestFactory;
 use Guzzle\Http\Message\Response as GuzzleResponse;
-use Guzzle\Http\Message\EntityEnclosingRequest;
+use InterNations\Component\HttpMock\PHPUnit\HttpMockFacade;
+use InterNations\Component\HttpMock\Server;
+use InterNations\Component\Testing\AbstractTestCase;
 use SuperClosure\SerializableClosure;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Process\Process;
 
 /**
  * @large
@@ -37,7 +37,7 @@ class AppIntegrationTest extends AbstractTestCase
     public static function tearDownAfterClass()
     {
         static::assertSame('', (string) static::$server1->getOutput(), (string) static::$server1->getOutput());
-        static::assertSame('', (string) static::$server1->getErrorOutput(), (string) static::$server1->getErrorOutput());
+        static::assertSame('', (string) HttpMockFacade::cleanErrorOutput(static::$server1->getErrorOutput()), (string) static::$server1->getErrorOutput());
         static::$server1->stop();
     }
 


### PR DESCRIPTION
In PHP 7.4 the built in PHP web server started to output every
request on the console. The changes filter all non error lines
before checking for errors.
No failing tests under 7.4 now.
Please check the tests from PHP 7.1 to 7.4 to be sure. But the fix should work in every version.