### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/Matcher/ExtractorFactoryTest.php
+++ b/tests/Matcher/ExtractorFactoryTest.php
@@ -112,7 +112,7 @@ class ExtractorFactoryTest extends AbstractTestCase
         $extractorFactory = new ExtractorFactory('/foo');
 
         $extractor = $extractorFactory->createHeaderExtractor('content-type');
-        $this->assertSame(null, $extractor($request));
+        $this->assertNull($extractor($request));
     }
 
     public function testHeaderExistsWithExistingHeader()

--- a/tests/PHPUnit/HttpMockPHPUnitIntegrationTest.php
+++ b/tests/PHPUnit/HttpMockPHPUnitIntegrationTest.php
@@ -275,8 +275,8 @@ class HttpMockPHPUnitIntegrationTest extends AbstractTestCase
 
         $this->assertSame('query string', (string) $this->http->client->get('/?key1=')->send()->getBody());
 
-        $this->assertEquals(Response::HTTP_NOT_FOUND, (string) $this->http->client->get('/')->send()->getStatusCode());
-        $this->assertEquals(Response::HTTP_NOT_FOUND, (string) $this->http->client->post('/')->send()->getStatusCode());
+        $this->assertSame(Response::HTTP_NOT_FOUND, $this->http->client->get('/')->send()->getStatusCode());
+        $this->assertSame(Response::HTTP_NOT_FOUND, $this->http->client->post('/')->send()->getStatusCode());
     }
 
     public function testMatchRegex()
@@ -312,17 +312,17 @@ class HttpMockPHPUnitIntegrationTest extends AbstractTestCase
             'response',
             (string) $this->http->client->get('/?p1=&p2=v2&p4=any&p5=v5&p6=v6')->send()->getBody()
         );
-        $this->assertEquals(
+        $this->assertSame(
             Response::HTTP_NOT_FOUND,
-            (string) $this->http->client->get('/?p1=&p2=v2&p3=foo')->send()->getStatusCode()
+            $this->http->client->get('/?p1=&p2=v2&p3=foo')->send()->getStatusCode()
         );
-        $this->assertEquals(
+        $this->assertSame(
             Response::HTTP_NOT_FOUND,
-            (string) $this->http->client->get('/?p1=')->send()->getStatusCode()
+            $this->http->client->get('/?p1=')->send()->getStatusCode()
         );
-        $this->assertEquals(
+        $this->assertSame(
             Response::HTTP_NOT_FOUND,
-            (string) $this->http->client->get('/?p3=foo')->send()->getStatusCode()
+            $this->http->client->get('/?p3=foo')->send()->getStatusCode()
         );
     }
 


### PR DESCRIPTION
# Changed log

- Using the `assertNull` to assert expected type is `null`.
- Using the `assertSame` to assert HTTP status code is `404` and removing casting string type:

```
Failed asserting that '404' is identical to 404.
```