### PR TITLE
Enable different responses on consecutive calls

### DIFF
--- a/doc/stubbing.md
+++ b/doc/stubbing.md
@@ -107,3 +107,32 @@ $this->http->mock
 
 By using `once()`, the second request will lead to a 404 HTTP Not Found, as if the request would have been undefined.
 Other methods to limit validity are `once()`, `twice()`, `thrice()` and `exactly(int $count)`.
+
+## Getting different response on successive identical queries
+
+In the previous section we saw how we could make a stub at most for N queries. But it's also possible to set up different responses on
+successive identical queries.
+
+```php
+      $this->builder
+          ->first()
+          ->when()
+              ->pathIs('/resource')
+              ->methodIs('POST')
+          ->then()
+              ->body('called once');
+      $this->builder
+          ->second()
+          ->when()
+              ->pathIs('/resource')
+              ->methodIs('POST')
+          ->then()
+              ->body('called twice');
+      $this->builder
+          ->nth(2) // "2" because the count starts at 0
+          ->when()
+              ->pathIs('/resource')
+              ->methodIs('POST')
+          ->then()
+              ->body('called 3 times');
+```

--- a/doc/stubbing.md
+++ b/doc/stubbing.md
@@ -129,7 +129,7 @@ successive identical queries.
           ->then()
               ->body('called twice');
       $this->builder
-          ->nth(2) // "2" because the count starts at 0
+          ->nth(3)
           ->when()
               ->pathIs('/resource')
               ->methodIs('POST')

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -24,22 +24,17 @@ class Expectation
     /** @var ExtractorFactory */
     private $extractorFactory;
 
-    /** @var boolean */
-    private $countARunEvenIfLimiterDoesntMatch;
-
     public function __construct(
         MockBuilder $mockBuilder,
         MatcherFactory $matcherFactory,
         ExtractorFactory $extractorFactory,
-        Closure $limiter,
-        bool $countARunEvenIfLimiterDoesntMatch = false
+        Closure $limiter
     )
     {
         $this->matcherFactory = $matcherFactory;
         $this->responseBuilder = new ResponseBuilder($mockBuilder);
         $this->extractorFactory = $extractorFactory;
         $this->limiter = $limiter;
-        $this->countARunEvenIfLimiterDoesntMatch = $countARunEvenIfLimiterDoesntMatch;
     }
 
     public function pathIs($matcher)
@@ -150,11 +145,6 @@ class Expectation
     public function getLimiter()
     {
         return new SerializableClosure($this->limiter);
-    }
-
-    public function getCountARunEvenIfNotSelected()
-    {
-        return $this->countARunEvenIfLimiterDoesntMatch;
     }
 
     private function appendMatcher($matcher, Closure $extractor = null)

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -24,17 +24,22 @@ class Expectation
     /** @var ExtractorFactory */
     private $extractorFactory;
 
+    /** @var boolean */
+    private $countARunEvenIfLimiterDoesntMatch;
+
     public function __construct(
         MockBuilder $mockBuilder,
         MatcherFactory $matcherFactory,
         ExtractorFactory $extractorFactory,
-        Closure $limiter
+        Closure $limiter,
+        bool $countARunEvenIfLimiterDoesntMatch = false
     )
     {
         $this->matcherFactory = $matcherFactory;
         $this->responseBuilder = new ResponseBuilder($mockBuilder);
         $this->extractorFactory = $extractorFactory;
         $this->limiter = $limiter;
+        $this->countARunEvenIfLimiterDoesntMatch = $countARunEvenIfLimiterDoesntMatch;
     }
 
     public function pathIs($matcher)
@@ -145,6 +150,11 @@ class Expectation
     public function getLimiter()
     {
         return new SerializableClosure($this->limiter);
+    }
+
+    public function getCountARunEvenIfNotSelected()
+    {
+        return $this->countARunEvenIfLimiterDoesntMatch;
     }
 
     private function appendMatcher($matcher, Closure $extractor = null)

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -24,17 +24,22 @@ class Expectation
     /** @var ExtractorFactory */
     private $extractorFactory;
 
+    /** @var int */
+    private $priority;
+
     public function __construct(
         MockBuilder $mockBuilder,
         MatcherFactory $matcherFactory,
         ExtractorFactory $extractorFactory,
-        Closure $limiter
+        Closure $limiter,
+        int $priority
     )
     {
         $this->matcherFactory = $matcherFactory;
         $this->responseBuilder = new ResponseBuilder($mockBuilder);
         $this->extractorFactory = $extractorFactory;
         $this->limiter = $limiter;
+        $this->priority = $priority;
     }
 
     public function pathIs($matcher)
@@ -130,6 +135,11 @@ class Expectation
         }
 
         return $closures;
+    }
+
+    public function getPriority()
+    {
+        return $this->priority;
     }
 
     public function then()

--- a/src/MockBuilder.php
+++ b/src/MockBuilder.php
@@ -7,6 +7,10 @@ use InterNations\Component\HttpMock\Matcher\MatcherFactory;
 
 class MockBuilder
 {
+    private const PRIORITY_ANY = 0;
+    private const PRIORITY_EXACTLY = 10;
+    private const PRIORITY_NTH = 100;
+
     /** @var Expectation[] */
     private $expectations = [];
 
@@ -49,7 +53,7 @@ class MockBuilder
         $this->limiter = static function ($runs) use ($times) {
             return $runs < $times;
         };
-        $this->priority = 1;
+        $this->priority = self::PRIORITY_EXACTLY;
 
         return $this;
     }
@@ -74,7 +78,7 @@ class MockBuilder
         $this->limiter = static function ($runs) use ($position) {
             return $runs === ($position - 1);
         };
-        $this->priority = 2;
+        $this->priority = $position * self::PRIORITY_NTH;
 
         return $this;
     }
@@ -84,7 +88,7 @@ class MockBuilder
         $this->limiter = static function () {
             return true;
         };
-        $this->priority = 0;
+        $this->priority = self::PRIORITY_ANY;
 
         return $this;
     }

--- a/src/MockBuilder.php
+++ b/src/MockBuilder.php
@@ -16,6 +16,9 @@ class MockBuilder
     /** @var Closure */
     private $limiter;
 
+    /** @var boolean */
+    private $countARunEvenIfLimiterDoesntMatch;
+
     /** @var ExtractorFactory */
     private $extractorFactory;
 
@@ -46,6 +49,32 @@ class MockBuilder
         $this->limiter = static function ($runs) use ($times) {
             return $runs < $times;
         };
+        $this->countARunEvenIfLimiterDoesntMatch = false;
+
+        return $this;
+    }
+
+    public function first()
+    {
+        return $this->nth(0);
+    }
+
+    public function second()
+    {
+        return $this->nth(1);
+    }
+
+    public function third()
+    {
+        return $this->nth(2);
+    }
+
+    public function nth($position)
+    {
+        $this->limiter = static function ($runs) use ($position) {
+            return $runs === $position;
+        };
+        $this->countARunEvenIfLimiterDoesntMatch = true;
 
         return $this;
     }
@@ -55,6 +84,7 @@ class MockBuilder
         $this->limiter = static function () {
             return true;
         };
+        $this->countARunEvenIfLimiterDoesntMatch = false;
 
         return $this;
     }
@@ -62,7 +92,7 @@ class MockBuilder
     /** @return Expectation */
     public function when()
     {
-        $this->expectations[] = new Expectation($this, $this->matcherFactory, $this->extractorFactory, $this->limiter);
+        $this->expectations[] = new Expectation($this, $this->matcherFactory, $this->extractorFactory, $this->limiter, $this->countARunEvenIfLimiterDoesntMatch);
 
         $this->any();
 

--- a/src/MockBuilder.php
+++ b/src/MockBuilder.php
@@ -16,9 +16,6 @@ class MockBuilder
     /** @var Closure */
     private $limiter;
 
-    /** @var boolean */
-    private $countARunEvenIfLimiterDoesntMatch;
-
     /** @var ExtractorFactory */
     private $extractorFactory;
 
@@ -49,32 +46,30 @@ class MockBuilder
         $this->limiter = static function ($runs) use ($times) {
             return $runs < $times;
         };
-        $this->countARunEvenIfLimiterDoesntMatch = false;
 
         return $this;
     }
 
     public function first()
     {
-        return $this->nth(0);
+        return $this->nth(1);
     }
 
     public function second()
     {
-        return $this->nth(1);
+        return $this->nth(2);
     }
 
     public function third()
     {
-        return $this->nth(2);
+        return $this->nth(3);
     }
 
     public function nth($position)
     {
         $this->limiter = static function ($runs) use ($position) {
-            return $runs === $position;
+            return $runs === ($position - 1);
         };
-        $this->countARunEvenIfLimiterDoesntMatch = true;
 
         return $this;
     }
@@ -84,7 +79,6 @@ class MockBuilder
         $this->limiter = static function () {
             return true;
         };
-        $this->countARunEvenIfLimiterDoesntMatch = false;
 
         return $this;
     }
@@ -92,7 +86,7 @@ class MockBuilder
     /** @return Expectation */
     public function when()
     {
-        $this->expectations[] = new Expectation($this, $this->matcherFactory, $this->extractorFactory, $this->limiter, $this->countARunEvenIfLimiterDoesntMatch);
+        $this->expectations[] = new Expectation($this, $this->matcherFactory, $this->extractorFactory, $this->limiter);
 
         $this->any();
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -86,10 +86,9 @@ class Server extends Process
                 '/_expectation',
                 null,
                 [
-                    'matcher'                    => serialize($expectation->getMatcherClosures()),
-                    'limiter'                    => serialize($expectation->getLimiter()),
-                    'response'                   => serialize($expectation->getResponse()),
-                    'countARunEvenIfLimiterDoesntMatch' => serialize($expectation->getCountARunEvenIfNotSelected()),
+                    'matcher' => serialize($expectation->getMatcherClosures()),
+                    'limiter' => serialize($expectation->getLimiter()),
+                    'response' => serialize($expectation->getResponse()),
                 ]
             )->send();
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -86,9 +86,10 @@ class Server extends Process
                 '/_expectation',
                 null,
                 [
-                    'matcher'  => serialize($expectation->getMatcherClosures()),
-                    'limiter'  => serialize($expectation->getLimiter()),
-                    'response' => serialize($expectation->getResponse()),
+                    'matcher'                    => serialize($expectation->getMatcherClosures()),
+                    'limiter'                    => serialize($expectation->getLimiter()),
+                    'response'                   => serialize($expectation->getResponse()),
+                    'countARunEvenIfLimiterDoesntMatch' => serialize($expectation->getCountARunEvenIfNotSelected()),
                 ]
             )->send();
 

--- a/src/app.php
+++ b/src/app.php
@@ -133,18 +133,15 @@ $app->error(
                     }
                 }
 
-                if (isset($expectation['limiter']) && !$expectation['limiter']($expectation['runs'])) {
-                    $notFoundResponse = new Response('Expectation no longer applicable', Response::HTTP_GONE);
-                    if ($expectation['countARunEvenIfLimiterDoesntMatch']) {
-                        ++$expectations[$pos]['runs'];
-                        $app['storage']->store($request, 'expectations', $expectations);
-
-                    }
-                    continue;
-                }
+                $applicable = !isset($expectation['limiter']) || $expectation['limiter']($expectation['runs']);
 
                 ++$expectations[$pos]['runs'];
                 $app['storage']->store($request, 'expectations', $expectations);
+
+                if (!$applicable) {
+                    $notFoundResponse = new Response('Expectation not met', Response::HTTP_GONE);
+                    continue;
+                }
 
                 if (method_exists($event, 'allowCustomResponseCode')) {
                     $event->allowCustomResponseCode();

--- a/src/app.php
+++ b/src/app.php
@@ -110,6 +110,10 @@ $app->post(
 $app->error(
     static function (Exception $e, Request $request, $code, GetResponseForExceptionEvent $event = null) use ($app) {
         if ($e instanceof NotFoundHttpException) {
+            if (method_exists($event, 'allowCustomResponseCode')) {
+                $event->allowCustomResponseCode();
+            }
+
             $app['storage']->append(
                 $request,
                 'requests',
@@ -141,10 +145,6 @@ $app->error(
                 if (!$applicable) {
                     $notFoundResponse = new Response('Expectation not met', Response::HTTP_GONE);
                     continue;
-                }
-
-                if (method_exists($event, 'allowCustomResponseCode')) {
-                    $event->allowCustomResponseCode();
                 }
 
                 return $expectation['response'];

--- a/src/app.php
+++ b/src/app.php
@@ -89,18 +89,13 @@ $app->post(
             }
         }
 
-        $countARunEvenIfLimiterDoesntMatch = false;
-        if ($request->request->has('countARunEvenIfLimiterDoesntMatch')) {
-            $countARunEvenIfLimiterDoesntMatch = Util::silentDeserialize($request->request->get('countARunEvenIfLimiterDoesntMatch'));
-        }
-
         // Fix issue with silex default error handling
         $response->headers->set('X-Status-Code', $response->getStatusCode());
 
         $app['storage']->prepend(
             $request,
             'expectations',
-            ['matcher' => $matcher, 'response' => $response, 'limiter' => $limiter, 'runs' => 0, 'countARunEvenIfLimiterDoesntMatch' => $countARunEvenIfLimiterDoesntMatch]
+            ['matcher' => $matcher, 'response' => $response, 'limiter' => $limiter, 'runs' => 0]
         );
 
         return new Response('', Response::HTTP_CREATED);

--- a/tests/MockBuilderIntegrationTest.php
+++ b/tests/MockBuilderIntegrationTest.php
@@ -186,6 +186,29 @@ class MockBuilderIntegrationTest extends TestCase
         $this->assertSame('any', (string) $this->server->getClient()->post('/resource')->send()->getBody());
     }
 
+    public function testCreateSuccessiveExpectationsInUnexpectedOrder()
+    {
+        $this->builder
+            ->second()
+            ->when()
+                ->pathIs('/resource')
+                ->methodIs('POST')
+            ->then()
+                ->body('2');
+        $this->builder
+            ->first()
+            ->when()
+                ->pathIs('/resource')
+                ->methodIs('POST')
+            ->then()
+                ->body('1');
+
+        $this->server->setUp($this->builder->flushExpectations());
+
+        $this->assertSame('1', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+        $this->assertSame('2', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+    }
+
     public function testCreateSuccessiveExpectationsWithOnce()
     {
         $this->builder

--- a/tests/MockBuilderIntegrationTest.php
+++ b/tests/MockBuilderIntegrationTest.php
@@ -141,7 +141,7 @@ class MockBuilderIntegrationTest extends TestCase
           ->then()
               ->body('called twice');
       $this->builder
-          ->nth(2)
+          ->nth(3)
           ->when()
               ->pathIs('/resource')
               ->methodIs('POST')

--- a/tests/MockBuilderIntegrationTest.php
+++ b/tests/MockBuilderIntegrationTest.php
@@ -123,4 +123,35 @@ class MockBuilderIntegrationTest extends TestCase
         $this->assertSame('POST 1', (string) $this->server->getClient()->post('/post-resource-1')->send()->getBody());
         $this->assertSame('POST 2', (string) $this->server->getClient()->post('/post-resource-2')->send()->getBody());
     }
+
+    public function testCreateSuccessiveExpectationsOnSameWhen()
+    {
+      $this->builder
+          ->first()
+          ->when()
+              ->pathIs('/resource')
+              ->methodIs('POST')
+          ->then()
+              ->body('called once');
+      $this->builder
+          ->second()
+          ->when()
+              ->pathIs('/resource')
+              ->methodIs('POST')
+          ->then()
+              ->body('called twice');
+      $this->builder
+          ->nth(2)
+          ->when()
+              ->pathIs('/resource')
+              ->methodIs('POST')
+          ->then()
+              ->body('called 3 times');
+
+      $this->server->setUp($this->builder->flushExpectations());
+
+      $this->assertSame('called once', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+      $this->assertSame('called twice', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+      $this->assertSame('called 3 times', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+    }
 }

--- a/tests/MockBuilderIntegrationTest.php
+++ b/tests/MockBuilderIntegrationTest.php
@@ -154,4 +154,68 @@ class MockBuilderIntegrationTest extends TestCase
       $this->assertSame('called twice', (string) $this->server->getClient()->post('/resource')->send()->getBody());
       $this->assertSame('called 3 times', (string) $this->server->getClient()->post('/resource')->send()->getBody());
     }
+
+    public function testCreateSuccessiveExpectationsWithAny()
+    {
+        $this->builder
+            ->first()
+            ->when()
+                ->pathIs('/resource')
+                ->methodIs('POST')
+            ->then()
+                ->body('1');
+        $this->builder
+            ->second()
+            ->when()
+                ->pathIs('/resource')
+                ->methodIs('POST')
+            ->then()
+                ->body('2');
+        $this->builder
+            ->any()
+                ->when()
+                ->pathIs('/resource')
+            ->methodIs('POST')
+            ->then()
+                ->body('any');
+
+        $this->server->setUp($this->builder->flushExpectations());
+
+        $this->assertSame('1', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+        $this->assertSame('2', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+        $this->assertSame('any', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+    }
+
+    public function testCreateSuccessiveExpectationsWithOnce()
+    {
+        $this->builder
+            ->first()
+            ->when()
+                ->pathIs('/resource')
+                ->methodIs('POST')
+            ->then()
+                ->body('1');
+        $this->builder
+            ->second()
+            ->when()
+                ->pathIs('/resource')
+                ->methodIs('POST')
+            ->then()
+                ->body('2');
+        $this->builder
+            ->twice()
+            ->when()
+                ->pathIs('/resource')
+                ->methodIs('POST')
+            ->then()
+                ->body('twice');
+
+        $this->server->setUp($this->builder->flushExpectations());
+
+        $this->assertSame('1', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+        $this->assertSame('2', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+        $this->assertSame('twice', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+        $this->assertSame('twice', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+        $this->assertSame('Expectation not met', (string) $this->server->getClient()->post('/resource')->send()->getBody());
+    }
 }

--- a/tests/PHPUnit/HttpMockMultiPHPUnitIntegrationTest.php
+++ b/tests/PHPUnit/HttpMockMultiPHPUnitIntegrationTest.php
@@ -140,7 +140,7 @@ class HttpMockMultiPHPUnitIntegrationTest extends AbstractTestCase
         $this->assertSame(200, $firstResponse->getStatusCode());
         $secondResponse = $this->http['firstNamedServer']->client->post('/')->send();
         $this->assertSame(410, $secondResponse->getStatusCode());
-        $this->assertSame('Expectation no longer applicable', $secondResponse->getBody(true));
+        $this->assertSame('Expectation not met', $secondResponse->getBody(true));
 
         $this->http['firstNamedServer']->mock
             ->exactly(2)
@@ -156,7 +156,7 @@ class HttpMockMultiPHPUnitIntegrationTest extends AbstractTestCase
         $this->assertSame(200, $secondResponse->getStatusCode());
         $thirdResponse = $this->http['firstNamedServer']->client->post('/')->send();
         $this->assertSame(410, $thirdResponse->getStatusCode());
-        $this->assertSame('Expectation no longer applicable', $thirdResponse->getBody(true));
+        $this->assertSame('Expectation not met', $thirdResponse->getBody(true));
 
         $this->http['firstNamedServer']->mock
             ->any()

--- a/tests/PHPUnit/HttpMockPHPUnitIntegrationTest.php
+++ b/tests/PHPUnit/HttpMockPHPUnitIntegrationTest.php
@@ -140,7 +140,7 @@ class HttpMockPHPUnitIntegrationTest extends AbstractTestCase
         $this->assertSame(200, $firstResponse->getStatusCode());
         $secondResponse = $this->http->client->post('/')->send();
         $this->assertSame(410, $secondResponse->getStatusCode());
-        $this->assertSame('Expectation no longer applicable', $secondResponse->getBody(true));
+        $this->assertSame('Expectation not met', $secondResponse->getBody(true));
 
         $this->http->mock
             ->exactly(2)
@@ -156,7 +156,7 @@ class HttpMockPHPUnitIntegrationTest extends AbstractTestCase
         $this->assertSame(200, $secondResponse->getStatusCode());
         $thirdResponse = $this->http->client->post('/')->send();
         $this->assertSame(410, $thirdResponse->getStatusCode());
-        $this->assertSame('Expectation no longer applicable', $thirdResponse->getBody(true));
+        $this->assertSame('Expectation not met', $thirdResponse->getBody(true));
 
         $this->http->mock
             ->any()


### PR DESCRIPTION
Based on #62

Three changes:
 * Always track the run count
 * Start counting at 1 for `nth()`
 * Introduce a priority to allow `any()`, `nth()` and `exactly()` to happily co-exist